### PR TITLE
Incorporate ramp rate calculations into Elevate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ browsers.karma.conf.js
 
 # local workspace folders
 .vscode/
+.DS_Store

--- a/plugin/app/src/app/fitness-trend/fitness-info-dialog/fitness-info-dialog.component.html
+++ b/plugin/app/src/app/fitness-trend/fitness-info-dialog/fitness-info-dialog.component.html
@@ -113,7 +113,7 @@
 			<katex [expression]="'Form_{(day)} = Fitness_{(day - 1)} - Fatigue_{(day - 1)}'"></katex>
 		</div>
 
-		<h2 class="mat-headline">Using training zones</h2>
+		<h2 class="mat-headline">Using training zones and fitness ramp rates</h2>
 
 		As explained in previous section, the athlete's <i>Form</i> is the difference between yesterday <i>Fitness</i>
 		and
@@ -145,6 +145,34 @@
 
 		<a href="http://www.joefrielsblog.com/2015/12/managing-training-using-tsb.html" target="_blank">Read more about
 			training zones from Joe Friels' blog</a>
+		<br /><br />
+
+		Another insight that an athlete can use to guide optimal training is called the <i>Ramp Rate</i> of <i>Fitness</i>.
+		Put simply, the <i>Ramp Rate</i> is a metric that monitors your rate of change in your <i>Fitness</i> over a
+		set time interval. For example, if your <i>Fitness</i> does not rise at all over a set time, then your
+		<i>Ramp Rate</i> would be zero, indicating stagnant growth. If your training load is reduced over a set time (e.g.
+		due to injury or vacation), then your <i>Ramp Rate</i> would be negative, indicating a loss of <i>Fitness</i>.
+		So then, the next logical step would be to investigate how quickly <i>Fitness</i> can change (i.e. <i>Ramp Rate</i>)
+		that indicates optimal training conditions without risk of overtraining, burnout, or injury.<br /><br />
+
+		Unfortunately, an optimal <i>Ramp Rate</i> is not as straightforward as the <i>Training Zone</i>
+		discussed previously. As <a href="https://support.trainerroad.com/hc/en-us/articles/202237810-Training-Stress-Ramp-Rate-and-Target-Ranges" target="_blank">TrainerRoad</a>
+		points out, some work has begun which seeks to compile data for optimal <i>Ramp Rates</i> based on athelete
+		ability. However, until that work is published, an athlete's <i>Ramp Rate</i> should very much be based on
+		the individual's comfort level, ability, and perception of exertion. Joe Friel has stated the he has found
+		a <i>Ramp Rate</i> of 5 to 8 points per week should be attainable for most athletes, while Alan Couzens has
+		stated that he feels a more conservative <i>Ramp Rate</i> of 3 to 5 points per week is better for long term growth. <br /><br />
+
+		Elevate shows four different <i>Ramp Rate</i> figures near the day's <i>Fitness</i>, <i>Fatigue</i>, and
+		<i>Form</i> for seven days, one month, three months, and one year. These figures are simply the difference
+		between the day's <i>Fitness</i> value and the corresponding <i>Fitness</i> value in the past. On the "black
+		box" graph, each day's weekly <i>Ramp Rate</i> (i.e. the difference in <i>Fitness</i> compared to seven days
+		prior) is calculated and plotted alongside the other measurements discussed aboved.<br /><br />
+
+		Read more about fitness ramp rates from <a href="https://joefrielsblog.com/the-ctl-ramp-rate/" target="_blank">
+		Joe Friel</a>, <a href="https://www.alancouzens.com/blog/CTLramp.html" target="_blank">Alan Couzens</a>, and
+		<a href="https://www.trainingpeaks.com/blog/understanding-trainingpeaks-ramp-rate-for-better-coaching/" target="_blank">TrainingPeaks</a>.
+
 	</div>
 
 	<div>

--- a/plugin/app/src/app/fitness-trend/fitness-trend-graph/fitness-trend-graph.component.html
+++ b/plugin/app/src/app/fitness-trend/fitness-trend-graph/fitness-trend-graph.component.html
@@ -80,6 +80,12 @@
 						<td>{{viewedDay.printForm()}}<span *ngIf="viewedDay.prevTsb" class="mat-caption"> ({{viewedDay.printDeltaForm()}})</span>
 						</td>
 					</tr>
+					<tr class="ramp-value">
+						<td>Ramp Rate</td>
+						<td><span *ngIf="viewedDay.rr7d">{{viewedDay.printRR7d()}}</span><span *ngIf="!viewedDay.rr7d">-</span><!--
+							--><span *ngIf="viewedDay.prevRR7d" class="mat-caption"> ({{viewedDay.printDeltaRampRate()}})</span>
+						</td>
+					</tr>
 
 				</table>
 

--- a/plugin/app/src/app/fitness-trend/fitness-trend-graph/fitness-trend-graph.component.ts
+++ b/plugin/app/src/app/fitness-trend/fitness-trend-graph/fitness-trend-graph.component.ts
@@ -137,9 +137,11 @@ export class FitnessTrendGraphComponent implements OnInit, OnChanges, OnDestroy 
 		const fatigueLine: GraphPointModel[] = [];
 		const fitnessLine: GraphPointModel[] = [];
 		const formLine: GraphPointModel[] = [];
+		const rampRateLine: GraphPointModel[] = [];
 		const previewFatigueLine: GraphPointModel[] = [];
 		const previewFitnessLine: GraphPointModel[] = [];
 		const previewFormLine: GraphPointModel[] = [];
+		const previewRampRateLine: GraphPointModel[] = [];
 		const activeLine: GraphPointModel[] = [];
 
 		_.forEach(this.fitnessTrend, (dayFitnessTrend: DayFitnessTrendModel) => {
@@ -163,6 +165,20 @@ export class FitnessTrendGraphComponent implements OnInit, OnChanges, OnDestroy 
 				hidden: dayFitnessTrend.previewDay
 			});
 
+			if (!dayFitnessTrend.rr7d) {
+				rampRateLine.push({
+					date: dayFitnessTrend.dateString,
+					value: 0,
+					hidden: dayFitnessTrend.previewDay
+				});
+			} else {
+				rampRateLine.push({
+					date: dayFitnessTrend.dateString,
+					value: dayFitnessTrend.rr7d,
+					hidden: dayFitnessTrend.previewDay
+				});
+			}
+
 			// Preview future fitness day
 			const isHiddenGraphPoint = (!dayFitnessTrend.previewDay && dayFitnessTrend.dateString !== today);
 			previewFatigueLine.push({
@@ -180,6 +196,12 @@ export class FitnessTrendGraphComponent implements OnInit, OnChanges, OnDestroy 
 			previewFormLine.push({
 				date: dayFitnessTrend.dateString,
 				value: dayFitnessTrend.tsb,
+				hidden: isHiddenGraphPoint
+			});
+
+			previewRampRateLine.push({
+				date: dayFitnessTrend.dateString,
+				value: dayFitnessTrend.rr7d,
 				hidden: isHiddenGraphPoint
 			});
 
@@ -205,9 +227,11 @@ export class FitnessTrendGraphComponent implements OnInit, OnChanges, OnDestroy 
 			fatigueLine,
 			fitnessLine,
 			formLine,
+			rampRateLine,
 			previewFatigueLine,
 			previewFitnessLine,
 			previewFormLine,
+			previewRampRateLine,
 			activeLine
 		);
 	}

--- a/plugin/app/src/app/fitness-trend/fitness-trend-graph/models/viewable-fitness-data.model.ts
+++ b/plugin/app/src/app/fitness-trend/fitness-trend-graph/models/viewable-fitness-data.model.ts
@@ -17,21 +17,25 @@ export class ViewableFitnessDataModel {
 	public fatigueLine: GraphPointModel[] = [];
 	public fitnessLine: GraphPointModel[] = [];
 	public formLine: GraphPointModel[] = [];
+	public rampRateLine: GraphPointModel[];
 	public fitnessTrendLines: GraphPointModel[][] = [];
 	public markers: MarkerModel[] = [];
 
 	public previewFatigueLine: GraphPointModel[] = [];
 	public previewFitnessLine: GraphPointModel[] = [];
 	public previewFormLine: GraphPointModel[] = [];
+	public previewRampRateLine: GraphPointModel[];
 	public activeLine: GraphPointModel[] = [];
 
 	constructor(markers: MarkerModel[],
 				fatigueLine: GraphPointModel[],
 				fitnessLine: GraphPointModel[],
 				formLine: GraphPointModel[],
+				rampRateLine: GraphPointModel[],
 				previewFatigueLine: GraphPointModel[],
 				previewFitnessLine: GraphPointModel[],
 				previewFormLine: GraphPointModel[],
+				previewRampRateLine: GraphPointModel[],
 				activeLine: GraphPointModel[]) {
 
 		this.markers = markers;
@@ -39,17 +43,21 @@ export class ViewableFitnessDataModel {
 		this.fatigueLine = fatigueLine;
 		this.fitnessLine = fitnessLine;
 		this.formLine = formLine;
+		this.rampRateLine = rampRateLine;
 		this.previewFatigueLine = previewFatigueLine;
 		this.previewFitnessLine = previewFitnessLine;
 		this.previewFormLine = previewFormLine;
+		this.previewRampRateLine = previewRampRateLine;
 		this.activeLine = activeLine;
 
 		this.fitnessTrendLines.push(MG.convert.date(this.fatigueLine, "date"));
 		this.fitnessTrendLines.push(MG.convert.date(this.fitnessLine, "date"));
 		this.fitnessTrendLines.push(MG.convert.date(this.formLine, "date"));
+		this.fitnessTrendLines.push(MG.convert.date(this.rampRateLine, "date"));
 		this.fitnessTrendLines.push(MG.convert.date(this.previewFatigueLine, "date"));
 		this.fitnessTrendLines.push(MG.convert.date(this.previewFitnessLine, "date"));
 		this.fitnessTrendLines.push(MG.convert.date(this.previewFormLine, "date"));
+		this.fitnessTrendLines.push(MG.convert.date(this.previewRampRateLine, "date"));
 		this.fitnessTrendLines.push(MG.convert.date(this.activeLine, "date"));
 	}
 

--- a/plugin/app/src/app/fitness-trend/fitness-trend-legend/fitness-trend-legend.component.html
+++ b/plugin/app/src/app/fitness-trend/fitness-trend-legend/fitness-trend-legend.component.html
@@ -78,7 +78,7 @@
 	</div>
 
 	<!--Fitness, Fatigue, Form values-->
-	<div fxFill fxLayout="row" fxLayoutAlign="end start" class="mat-headline">
+	<div fxFill fxLayout="row" fxLayoutAlign="end start" class="mat-headline fix-margin-none">
 
 		<div fxFlex fxLayout="row" fxLayoutAlign="end start">
 			<div fxFlex="150px" class="ctl-value">
@@ -107,5 +107,19 @@
 				</div>
 			</div>
 		</div>
+	</div>
+
+	<!-- Ramp Rate Display -->
+	<div fxFill fxFlexAlign="end" fxLayout="row" fxLayoutAlign="end start" class="fix-margin-add">
+		<span fxFlexAlign="end">
+			<span *ngIf="!viewedDay.rr7d"><i>No fitness ramp rates</i></span>
+			<span *ngIf="viewedDay.rr7d">
+				<span>Fitness Ramp Rates: 7d&nbsp;<span class="ramp-value">{{viewedDay.printRR7d()}}</span></span><!--
+				--><span *ngIf="viewedDay.rr28d">,&nbsp;28d&nbsp;<span class="ramp-value">{{viewedDay.printRR28d()}}</span></span><!--
+				--><span *ngIf="viewedDay.rr90d">,&nbsp;90d&nbsp;<span class="ramp-value">{{viewedDay.printRR90d()}}</span></span><!--
+				--><span *ngIf="viewedDay.rr365d">,&nbsp;365d&nbsp;<span class="ramp-value">{{viewedDay.printRR365d()}}</span>
+				</span>.
+			</span>
+		</span>
 	</div>
 </div>

--- a/plugin/app/src/app/fitness-trend/fitness-trend-legend/fitness-trend-legend.component.scss
+++ b/plugin/app/src/app/fitness-trend/fitness-trend-legend/fitness-trend-legend.component.scss
@@ -2,3 +2,11 @@
 	font-style: italic;
 	min-height: 20px;
 }
+
+.fix-margin-none {
+	margin: 0 !important;
+}
+
+.fix-margin-add {
+	margin: 0 0 16px !important;
+}

--- a/plugin/app/src/app/fitness-trend/fitness-trend.component.theme.scss
+++ b/plugin/app/src/app/fitness-trend/fitness-trend.component.theme.scss
@@ -13,6 +13,7 @@ $config: mat-typography-config();
 	// Extract whichever individual palettes you need from the theme.
 	$primary: map-get($theme, primary);
 	$accent: map-get($theme, accent);
+	$warn: map-get($theme, warn);
 
 	$accent-color: mat-color($accent);
 	$primary-color: mat-color($primary);
@@ -21,6 +22,7 @@ $config: mat-typography-config();
 	$ctl-color: $accent-color;
 	$atl-color: $primary-color;
 	$tsb-color: mat-color($primary, 900);
+	$ramp-color: mat-color($warn, default);
 
 	$caption-font-size: mat-font-size($config, caption);
 	$body-1-font-size: mat-font-size($config, body-1);
@@ -50,12 +52,15 @@ $config: mat-typography-config();
 	.tsb-value {
 		color: $tsb-color;
 	}
+	.ramp-value {
+		color: $ramp-color;
+	}
 
 	#fitnessTrendGraph {
 
 		// Lines
 
-		// 1
+		// 1 - Fatigue
 		.mg-area1-color {
 			fill: $atl-color;
 			fill-opacity: 0.35;
@@ -65,7 +70,7 @@ $config: mat-typography-config();
 			stroke: $atl-color;
 		}
 
-		// 2
+		// 2 - Fitness
 		.mg-area2-color {
 			fill: $ctl-color;
 			fill-opacity: 0.35;
@@ -75,7 +80,7 @@ $config: mat-typography-config();
 			stroke: $ctl-color;
 		}
 
-		// 3
+		// 3 - Form
 		.mg-area3-color {
 			fill: $tsb-color;
 			fill-opacity: 0.35;
@@ -85,45 +90,66 @@ $config: mat-typography-config();
 			stroke: $tsb-color;
 		}
 
-		// 4
+		// 4 - Ramp Rate
+		.mg-area4-color {
+			fill: $ramp-color;
+			fill-opacity: 0.35;
+		}
+
 		.mg-line4-color {
+			stroke: $ramp-color;
+		}
+
+		// 5 - Preview Fatigue
+		.mg-line5-color {
 			stroke: $atl-color;
 			stroke-dasharray: 5, 5;
 		}
 
-		.mg-area4-color {
+		.mg-area5-color {
 			fill: $atl-color;
 			fill-opacity: 0.10;
 		}
 
-		// 5
-		.mg-area5-color {
+		// 6 - Preview Fitness
+		.mg-area6-color {
 			fill: $ctl-color;
 			fill-opacity: 0.10;
 		}
 
-		.mg-line5-color {
+		.mg-line6-color {
 			stroke: $ctl-color;
 			stroke-dasharray: 5, 5;
 		}
 
-		// 6
-		.mg-area6-color {
+		// 7 - Preview Form
+		.mg-area7-color {
 			fill: $tsb-color;
 			fill-opacity: 0.10;
 		}
 
-		.mg-line6-color {
+		.mg-line7-color {
 			stroke: $tsb-color;
 			stroke-dasharray: 5, 5;
 		}
 
-		// 7 (active line)
-		.mg-area7-color {
+		// 8 - Preview Ramp Rate
+		.mg-area8-color {
+			fill: $ramp-color;
+			fill-opacity: 0.10;
+		}
+
+		.mg-line8-color {
+			stroke: $ramp-color;
+			stroke-dasharray: 5, 5;
+		}
+
+		// 9 (active line)
+		.mg-area9-color {
 			fill: $text-color;
 		}
 
-		.mg-line7-color {
+		.mg-line9-color {
 			fill: $text-color;
 			fill-opacity: 0.35;
 			stroke: $text-color;
@@ -144,7 +170,7 @@ $config: mat-typography-config();
 		display: none;
 
 		width: 220px;
-		height: 145px;
+		height: 167px;
 		border-radius: 3px;
 
 		border: 1px solid mat-color($foreground, text, 0.25); // Use from text color

--- a/plugin/app/src/app/fitness-trend/shared/models/day-fitness-trend.model.ts
+++ b/plugin/app/src/app/fitness-trend/shared/models/day-fitness-trend.model.ts
@@ -31,6 +31,10 @@ export class DayFitnessTrendModel extends DayStressModel {
 		this.prevAtl = (prevAtl) ? prevAtl : null;
 		this.prevTsb = (prevTsb) ? prevTsb : null;
 
+		//initialize all ramp rates to null b/c they will be set when needed
+		this.rr7d = this.rr28d = this.rr90d = this.rr365d = null;
+		this.prevRR7d = this.prevRR28d = this.prevRR90d = this.prevRR365d = null;
+		
 		this.trainingZone = this.findTrainingZone(this.tsb);
 	}
 
@@ -43,6 +47,16 @@ export class DayFitnessTrendModel extends DayStressModel {
 	public prevCtl: number;
 	public prevAtl: number;
 	public prevTsb: number;
+
+	public rr7d: number;
+	public rr28d: number;
+	public rr90d: number;
+	public rr365d: number;
+
+	public prevRR7d: number;
+	public prevRR28d: number;
+	public prevRR90d: number;
+	public prevRR365d: number;
 
 	public trainingZone: TrainingZone;
 	public trainingZoneAsString: string;
@@ -82,6 +96,39 @@ export class DayFitnessTrendModel extends DayStressModel {
 		const delta = _.floor(this.tsb, 1) - _.floor(this.prevTsb, 1);
 		return ((delta >= 0) ? "+" : "") + _.round(delta, 1);
 	}
+
+	public printRR7d(): number {
+		if (!this.rr7d)
+			return null;
+		return _.floor(this.rr7d, 1);
+	}
+
+	public printRR28d(): number {
+		if (!this.rr28d)
+			return null;
+		return _.floor(this.rr28d, 1);
+	}
+
+	public printRR90d(): number {
+		if (!this.rr90d)
+			return null;
+		return _.floor(this.rr90d, 1);
+	}
+
+	public printRR365d(): number {
+		if (!this.rr365d)
+			return null;
+		return _.floor(this.rr365d, 1);
+	}
+
+	public printDeltaRampRate(): string {
+		if (!this.prevRR7d) {
+			return null;
+		}
+		const delta = _.floor(this.rr7d, 1) - _.floor(this.prevRR7d, 1);
+		return ((delta >= 0) ? "+" : "") + _.round(delta, 1);
+	}
+
 
 	public printDate(): string {
 

--- a/plugin/app/src/app/fitness-trend/shared/services/fitness.service.ts
+++ b/plugin/app/src/app/fitness-trend/shared/services/fitness.service.ts
@@ -235,6 +235,7 @@ export class FitnessService {
 				.then((dailyActivity: DayStressModel[]) => {
 
 					let ctl, atl, tsb;
+					let rr7d, rr28d, rr90d, rr365d = null;
 
 					const fitnessTrend: DayFitnessTrendModel[] = [];
 
@@ -291,6 +292,24 @@ export class FitnessService {
 
 						if (_.isNumber(dayStress.finalStressScore) && dayStress.finalStressScore > 0) {
 							dayFitnessTrend.finalStressScore = dayStress.finalStressScore;
+						}
+
+						//Calculate the ramp rates
+						if (index >= 7 ) { //only calculate weekly RR if we have a week of data
+							dayFitnessTrend.rr7d = _.floor(ctl, 1) - _.floor(fitnessTrend[index - 7].ctl, 1);
+							dayFitnessTrend.prevRR7d = previousDayFitnessTrend.rr7d;
+						}
+						if (index >= 28 ) { //only calculate monthly RR if we have a month of data
+							dayFitnessTrend.rr28d = _.floor(ctl, 1) - _.floor(fitnessTrend[index - 28].ctl, 1);
+							dayFitnessTrend.prevRR28d = previousDayFitnessTrend.rr28d;
+						}
+						if (index >= 90 ) { //only calculate 3mo RR if we have 3mo of data
+							dayFitnessTrend.rr90d = _.floor(ctl, 1) - _.floor(fitnessTrend[index - 90].ctl, 1);
+							dayFitnessTrend.prevRR90d = previousDayFitnessTrend.rr90d;
+						}
+						if (index >= 365 ) { //only calculate yearly RR if we have a year of data
+							dayFitnessTrend.rr365d = _.floor(ctl, 1) - _.floor(fitnessTrend[index - 365].ctl, 1);
+							dayFitnessTrend.prevRR365d = previousDayFitnessTrend.rr365d;
 						}
 
 						previousDayFitnessTrend = dayFitnessTrend;

--- a/plugin/app/src/app/styles/themes/dark.scss
+++ b/plugin/app/src/app/styles/themes/dark.scss
@@ -2,4 +2,5 @@
 
 $dark-primary: mat-palette($mat-yellow);
 $dark-accent: mat-palette($mat-purple, 200);
-$dark-theme: mat-dark-theme($dark-primary, $dark-accent);
+$dark-warn: mat-palette($mat-green, 300);
+$dark-theme: mat-dark-theme($dark-primary, $dark-accent, $dark-warn);

--- a/plugin/app/src/app/styles/themes/light.scss
+++ b/plugin/app/src/app/styles/themes/light.scss
@@ -2,4 +2,5 @@
 
 $light-primary: mat-palette($mat-grey, 500);
 $light-accent: mat-palette($mat-deep-orange);
-$light-theme: mat-light-theme($light-primary, $light-accent);
+$light-warn: mat-palette($mat-blue, 600);
+$light-theme: mat-light-theme($light-primary, $light-accent, $light-warn);


### PR DESCRIPTION
To complete this feature, the dayFitnessTrend model and fitness service were changed to calculate fitness ramp rates for 7 days, 28 days, 90 days, and 365 days in the past. The fitness-trend-legend component was modified to display the ramp rates below the fitness, fatigue, and form values for the displayed day. The graph component and viewableFitnessData models were modified to include the plot for the weekly ramp rate (similar to how Golden Cheetah displays this plot). The Elevate themes were modified to incorporate a third color (the primary and secondary palletes did not give much room for a different enough color) as the warn color (I saw some references to using the angular warn color, but one was never set, so I don't think this will affect anything). Finally, a description of how to interpret ramp rate and links to resources was added to the fitness-info-dialog component.